### PR TITLE
golint comments added, MIT License added, gologger_test.go added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
-.idea/*
+.DS_Store
+.vscode

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 qbxt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# gologger
+
+## Purpose
+
+`gologger` provides a simple wrapper around the `logrus` logging package in an intuitive manner. Using this 
+package in conjunction with `logrus` should slim the codebase down and be a little more intuitive.
+
+## Installation
+`go get -d -v github.com/qbxt/gologger`
+
+## Example
+
+```go
+package main
+
+import (
+    "errors"
+
+    "github.com/qbxt/gologger"
+    "github.com/sirupsen/logrus"
+)
+
+func main() {
+    gologger.Init(logrus.InfoLevel)
+
+    gologger.Debug("This is a Debug message", nil)
+    gologger.Debug("This is a Debug message", logrus.Fields{"log_message": "Here's a Debug message"})
+    gologger.Info("This is an Info message", logrus.Fields{"log_message": "Here's an Info message"})
+
+    err := errors.New("This is a generic error!")
+    gologger.Warn("This is a Warn message", err, nil)
+    gologger.Error("This is an Error message", err, nil)
+    gologger.Fatal("This is a Fatal message", err, logrus.Fields{"log_message": "Something is very very wrong"})
+}
+```

--- a/gologger.go
+++ b/gologger.go
@@ -1,4 +1,4 @@
-// Package gologger package is used as a simple wrapper for the logrus
+// Package gologger is used as a simple wrapper for the logrus
 // logging package. This simple layer of abstraction requires less
 // code and can keep code much cleaner in the end.
 package gologger

--- a/gologger.go
+++ b/gologger.go
@@ -1,14 +1,27 @@
+// Package gologger package is used as a simple wrapper for the logrus
+// logging package. This simple layer of abstraction requires less
+// code and can keep code much cleaner in the end.
 package gologger
 
+// only import needed is logrus
 import (
 	"github.com/sirupsen/logrus"
-	"syscall"
 )
 
-func Init() {
-	logrus.SetLevel(logrus.DebugLevel)
+// Init globally sets the logger level to the provided logrus.Level - which can be any of:
+//  * logrus.PanicLevel
+//  * logrus.FatalLevel
+//  * logrus.ErrorLevel
+//  * logrus.WarnLevel
+//  * logrus.InfoLevel
+//  * logrus.DebugLevel
+func Init(l logrus.Level) {
+	logrus.SetLevel(l)
 }
 
+// Debug writes a message to the log of Debug level status. Requires:
+//  * message (string): helpful, user friendly error text
+//  * fields (logrus.Fields): Can be nil. If set, provide these logrus.Fields to the entry
 func Debug(message string, fields logrus.Fields) {
 	if fields != nil {
 		logrus.WithFields(fields).Debug(message)
@@ -17,6 +30,9 @@ func Debug(message string, fields logrus.Fields) {
 	}
 }
 
+// Info writes a message to the log of Info level status. Requires:
+//  * message (string): helpful, user friendly error text
+//  * fields (logrus.Fields): Can be nil. If set, provide these logrus.Fields to the entry
 func Info(message string, fields logrus.Fields) {
 	if fields != nil {
 		logrus.WithFields(fields).Info(message)
@@ -25,6 +41,10 @@ func Info(message string, fields logrus.Fields) {
 	}
 }
 
+// Warn writes a message to the log of Warn level status. Requires:
+//  * message (string): helpful, user friendly error text
+//  * err (error): An error obtained from a failed call to a previous method or function
+//  * fields (logrus.Fields): Can be nil. If set, provide these logrus.Fields to the entry
 func Warn(message string, err error, fields logrus.Fields) {
 	if fields != nil {
 		fields["error"] = err
@@ -37,13 +57,15 @@ func Warn(message string, err error, fields logrus.Fields) {
 	}
 }
 
-/**
- * Alias for logger.Warn
- */
+// Warning is an alias for Warn. Will call Warn() with provided options
 func Warning(message string, err error, fields logrus.Fields) {
 	Warn(message, err, fields)
 }
 
+// Error writes a message to the log of Error level status. Requires:
+//  * message (string): helpful, user friendly error text
+//  * err (error): An error obtained from a failed call to a previous method or function
+//  * fields (logrus.Fields): Can be nil. If set, provide these logrus.Fields to the entry
 func Error(message string, err error, fields logrus.Fields) {
 	if fields != nil {
 		fields["error"] = err
@@ -56,6 +78,12 @@ func Error(message string, err error, fields logrus.Fields) {
 	}
 }
 
+// Fatal writes a message to the log of Fatal level status. Requires:
+//  * message (string): helpful, user friendly error text
+//  * err (error): An error obtained from a failed call to a previous method or function
+//  * fields (logrus.Fields): Can be nil. If set, provide these logrus.Fields to the entry
+// Note: Calling a Fatal() error will exit execution of the current program. Goroutines will not
+// execute on deferral. Only call Fatal() if you are sure that the program should exit as well.
 func Fatal(message string, err error, fields logrus.Fields) {
 	if fields != nil {
 		fields["error"] = err
@@ -66,5 +94,4 @@ func Fatal(message string, err error, fields logrus.Fields) {
 	} else {
 		logrus.Fatal(message)
 	}
-	syscall.Exit(1)
 }

--- a/gologger_test.go
+++ b/gologger_test.go
@@ -1,0 +1,53 @@
+package gologger
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestInit(t *testing.T) {
+	Init(logrus.InfoLevel)
+}
+
+func TestDebug(t *testing.T) {
+	// without logrus.Fields
+	Debug("This is a Debug message", nil)
+	// with logrus.Fields
+	Debug("This is a Debug message", logrus.Fields{"log_message": "Here's a Debug message"})
+}
+
+func TestInfo(t *testing.T) {
+	Info("This is an Info message", nil)
+	Info("This is an Info message", logrus.Fields{"log_message": "Here's an Info message"})
+}
+
+func TestWarn(t *testing.T) {
+	err := errors.New("This is an error from Warn")
+	// test with no error or fields
+	Warn("This is a Warn message", nil, nil)
+	// error and no fields
+	Warn("This is a Warn message", err, nil)
+	// error and fields
+	Warn("This is a Warn message", err, logrus.Fields{"log_message": "Here's a Warn message"})
+
+}
+
+func TestWarning(t *testing.T) {
+	err := errors.New("This is an error from Warning")
+	Warning("This is a Warn message", nil, nil)
+	Warning("This is a Warn message", err, nil)
+	Warning("This is a Warn message", err, logrus.Fields{"log_message": "Here's a Warning message"})
+}
+
+func TestError(t *testing.T) {
+	err := errors.New("This is an error from Error")
+	Error("This is an Error message", nil, nil)
+	Error("This is an Error message", err, nil)
+	Error("This is an Error message", err, logrus.Fields{"log_message": "Here's an Error message"})
+}
+
+// Unfortunately, there doesn't seem to be a good way to test Fatal(), as it exits and if tested directly will
+// make the whole test fail. There is a solution out there: https://stackoverflow.com/questions/26225513/how-to-test-os-exit-scenarios-in-go
+// However, these passed tests won't count towards the percentage of passed tests.


### PR DESCRIPTION
Most of what I worked on was to get this in line with a properly commented / formatted go package. Here's all of what I did:
 - Added comments to functions that now pass `go lint`
 - MIT License added
 - Testing suite added (sans `Fatal()` - can't test coverage for an exiting function)
 - Removed `.idea/*` from gitignore, as `.idea` already covers it
 - Removed `syscall.Exit()` from `Fatal`, as logrus will exit for you

After this is merged, I'd like to use this personally for logging, and you should totally put it up as a package. To do that, you'd just have to make a new Release titled "v1.0.0", then run this command:

`GOPROXY=https://proxy.golang.org GO111MODULE=on go get -v github.com/qbxt/gologger@v1.0.0`